### PR TITLE
Addressing persistent volume permissions issue and default user creation inside the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ WORKDIR /app
 
 EXPOSE 80
 
-RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
+# RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
 
 COPY --from=builder --chown=app:app /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder --chown=app:app /app/ /app/
@@ -58,7 +58,7 @@ COPY --from=builder --chown=app:app /app/ /app/
 # Forwards media listener logs to stdout so they can be captured in docker logs.
 RUN ln -sf /dev/stdout /app/log/media_listener_production.log
 
-USER app
+# USER app
 
 ENTRYPOINT ["docker/entrypoint.sh"]
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ docker run -p 3000:3000 ghcr.io/blackcandy-org/blackcandy:latest
 
 ### Media Files Mounts 
 
+You can mount media files from host to container and use `MEDIA_PATH` environment variable to set the media path for black candy. You can now provide the uid and gid as env arguments so that the permissions of "<your_media_data_path>" is properly aligned with media path set for black candy above.
+
+```shell
+docker run -e UID=$(id -u) -e GID=$(id -g) -v <your_media_data_path>:/media_data -e MEDIA_PATH=/media_data ghcr.io/blackcandy-org/blackcandy:latest   
+```
+
+### Media Files Mounts 
+
 You can mount media files from host to container and use `MEDIA_PATH` environment variable to set the media path for black candy.
 
 ```shell

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,17 @@
 #!/bin/sh
 
+# Default to UID and GID 1000 if not provided
+USER_ID=${UID:-1000}
+GROUP_ID=${GID:-1000}
+
+# Create group and user with the specified IDs
+addgroup -g "$GROUP_ID" usergroup
+adduser -u "$USER_ID" -G usergroup username
+
+# Change ownership of the working directory
+chown -R "$USER_ID":"$GROUP_ID" /media_data
+
+
 if [ -z ${SECRET_KEY_BASE+x} ]; then
   echo "Generating SECRET_KEY_BASE environment variable."
   echo "Please attention, all old sessions will become invalid."

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,7 +9,7 @@ addgroup -g "$GROUP_ID" usergroup
 adduser -u "$USER_ID" -G usergroup username
 
 # Change ownership of the working directory
-chown -R "$USER_ID":"$GROUP_ID" /media_data
+chown -R "$USER_ID":"$GROUP_ID" "$MEDIA_PATH"
 
 
 if [ -z ${SECRET_KEY_BASE+x} ]; then


### PR DESCRIPTION
Currently the docker image has a default user "app" with the uid and gid set to 1000. this is causing difficulty in mapping the persistent storage from the host with a different uid and gid. Addressed in this issue #403. Not sure what exactly is the purpose of the default user inside the image. 

I removed the default user creation and now the user & group gets created as part of the entrypoint script based on the uid and gid given from the docker run command as an env variable. The changes in this PR will take care of the user permissions of the directories mounted. 

I am using this updated docker images in my homelab and I have no problem in using the blackcandy to play songs till now. Hope this is helpful