### PR TITLE
Bump Brakeman to 8.0.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     browser (6.2.0)
     builder (3.3.0)
@@ -488,7 +488,7 @@ CHECKSUMS
   bigdecimal (4.1.1) sha256=1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.18.6) sha256=0ae2393c1e911e38be0f24e9173e7be570c3650128251bf06240046f84a07d00
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   browser (6.2.0) sha256=281d5295788825c9396427c292c2d2be0a5c91875c93c390fde6e5d61a5ace2d
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bullet (8.1.0) sha256=604b7e2636ec2137dcab3ba61a56248c39a0004a0c9405d58bad0686d23b98ff


### PR DESCRIPTION
## Summary
- Bump Brakeman from 8.0.4 to 8.0.5 in Gemfile.lock.
- Fix the `scan_ruby` CI failure caused by `bin/brakeman` running with `--ensure-latest`.

## Root cause
`bin/brakeman` prepends `--ensure-latest`, so CI fails when the locked Brakeman version is behind the latest released gem even if the scan has no active findings.

## Validation
- `docker run --rm -v "$PWD:/rails" -w /rails -e BUNDLE_FROZEN=true ruby:4.0.2-alpine sh -lc 'apk add --no-cache build-base git libpq-dev yaml-dev vips-dev tzdata gcompat >/dev/null && bundle install --jobs 4 --retry 3 && bin/brakeman --no-pager'`\n- Result: Brakeman v8.0.5, 0 security warnings, 3 ignored warnings.