### PR TITLE
fix: morph custom Turbo renders instead of replacing elements

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,4 +1,7 @@
 import '@hotwired/turbo-rails'
+// TODO: Drop this dependency for Turbo's own exported morph once it ships.
+// See https://github.com/hotwired/turbo/pull/1438
+import { Idiomorph } from 'idiomorph'
 import './controllers'
 
 import Player from './player'
@@ -22,9 +25,9 @@ window.addEventListener('turbo:before-render', ({ detail }) => {
     const newAppContainer = newElement.querySelector('#js-app')
 
     if (appContainer && newAppContainer) {
-      appContainer.replaceWith(newAppContainer)
+      Idiomorph.morph(appContainer, newAppContainer)
     } else {
-      document.body.replaceWith(newElement)
+      Idiomorph.morph(currentElement, newElement)
     }
   }
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@hotwired/turbo-rails": "^8.0.0",
         "esbuild": "^0.18.17",
         "howler": "^2.2.3",
+        "idiomorph": "^0.7.4",
         "sass": "^1.64.2"
       },
       "devDependencies": {
@@ -2597,6 +2598,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/idiomorph": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/idiomorph/-/idiomorph-0.7.4.tgz",
+      "integrity": "sha512-uCdSpLo3uMfqOmrwXTpR1k/sq4sSmKC7l4o/LdJOEU+MMMq+wkevRqOQYn3lP7vfz9Mv+USBEqPvi0XhdL9ENw==",
+      "license": "0BSD"
     },
     "node_modules/ignore": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@hotwired/turbo-rails": "^8.0.0",
     "esbuild": "^0.18.17",
     "howler": "^2.2.3",
+    "idiomorph": "^0.7.4",
     "sass": "^1.64.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The custom turbo:before-render handler swapped #js-app with replaceWith and fell back to document.body.replaceWith. When a cached snapshot was restored without a usable #js-app, the fallback fired and reloaded the whole page, including the permanent player aside.

Morph the elements with Idiomorph instead so the live DOM is updated in place and the player is kept across navigations.