### PR TITLE
[skip ci] Updated the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,23 +28,6 @@ docker run -p 80:80 ghcr.io/blackcandy-org/blackcandy:latest
 # Or pull from Docker Hub.
 docker run -p 80:80 blackcandy/blackcandy:latest 
 ```
-
-or if you are using Docker Compose:
-
-```YAML
-services:
-  app:
-    container_name: 'blackcandy_app'
-    image: ghcr.io/blackcandy-org/blackcandy:latest
-    ports:
-      - "3000:80"
-    volumes:
-      - ./storage_data:/app/storage # Application Data storage
-      - /media_data:/media_data # Your media goes here
-    environment:
-      MEDIA_PATH: /media_data
-```
-
 That's all. Now, you can access either http://localhost or http://host-ip in a browser, and use initial admin user to log in (email: admin@admin.com, password: foobar).
 
 ## Upgrade
@@ -147,6 +130,29 @@ docker run -e SECRET_KEY_BASE=your_generated_secret ghcr.io/blackcandy-org/black
 ```
 
 If `SECRET_KEY_BASE` is not set, Black Candy will generate a new one on each startup, which will invalidate all existing sessions.
+
+### Example
+
+And if you would like to use docker compose instead of the CLI commands:
+
+```YAML
+services:
+  app:
+    image: ghcr.io/blackcandy-org/blackcandy:latest
+    restart: unless-stopped
+    ports:
+      - "3000:80" # Don't forget to check for port conflicts on the host
+    volumes:
+      - storage_data:/app/storage # Application Data storage
+      - ./media_data:/media_data # Your media goes here
+    environment:
+      SECRET_KEY_BASE: fake_secret_key # Don't forget to generate one using 'openssl rand -hex 64' on the console
+      MEDIA_PATH: /media_data
+
+volumes:
+  storage_data: # Required to avoid database corruption issues.
+```
+
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ docker run -p 80:80 ghcr.io/blackcandy-org/blackcandy:latest
 docker run -p 80:80 blackcandy/blackcandy:latest 
 ```
 
+or if you are using Docker Compose:
+
+```YAML
+services:
+  app:
+    container_name: 'blackcandy_app'
+    image: ghcr.io/blackcandy-org/blackcandy:latest
+    ports:
+      - "3000:80"
+    volumes:
+      - ./storage_data:/app/storage # Application Data storage
+      - /media_data:/media_data # Your media goes here
+    environment:
+      MEDIA_PATH: /media_data
+```
+
 That's all. Now, you can access either http://localhost or http://host-ip in a browser, and use initial admin user to log in (email: admin@admin.com, password: foobar).
 
 ## Upgrade

--- a/README.md
+++ b/README.md
@@ -57,17 +57,17 @@ That's all. Now, you can access either http://localhost or http://host-ip in a b
 Upgrade Black Candy is pull new image from remote. Then remove an old container and create a new one.
 
 ```shell
-docker pull ghcr.io/blackcandy-org/blackcandy:latest
 docker stop <your_blackcandy_container>
 docker rm <your_blackcandy_container>
+docker pull ghcr.io/blackcandy-org/blackcandy:latest
 docker run <OPTIONS> ghcr.io/blackcandy-org/blackcandy:latest 
 ```
 
 With docker compose, you can upgrade Black Candy like this:
 
 ```shell
-docker pull ghcr.io/blackcandy-org/blackcandy:latest
 docker-compose down
+docker pull ghcr.io/blackcandy-org/blackcandy:latest
 docker-compose up
 ```
 


### PR DESCRIPTION
I've included an example for docker compose and changed the order of commands for when you need to update or upgrade the image/instance.

I would add a more complex on example with docker compose that would replace some sessions of the read me (mainly the ones before the "Environment Variables" table) but i thought about waiting for a feedback from you.

My apologies for bothering at this time and hope this is an enjoyable contribution to the project.