### PR TITLE
Expose minimum CLI version

### DIFF
--- a/app/views/systems/show.json.jbuilder
+++ b/app/views/systems/show.json.jbuilder
@@ -10,3 +10,9 @@ json.min_app_version do
   json.minor BlackCandy::MinAppVersion::MINOR
   json.patch BlackCandy::MinAppVersion::PATCH
 end
+
+json.min_cli_version do
+  json.major BlackCandy::MinCliVersion::MAJOR
+  json.minor BlackCandy::MinCliVersion::MINOR
+  json.patch BlackCandy::MinCliVersion::PATCH
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,7 @@ require "rails/test_unit/railtie"
 require_relative "../lib/black_candy/errors"
 require_relative "../lib/black_candy/version"
 require_relative "../lib/black_candy/min_app_version"
+require_relative "../lib/black_candy/min_cli_version"
 require_relative "../lib/black_candy/configurable"
 
 # Require the gems listed in Gemfile, including any gems

--- a/lib/black_candy/min_cli_version.rb
+++ b/lib/black_candy/min_cli_version.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module BlackCandy
+  module MinCliVersion
+    MAJOR = 0
+    MINOR = 1
+    PATCH = 0
+  end
+end

--- a/test/controllers/systems_controller_test.rb
+++ b/test/controllers/systems_controller_test.rb
@@ -22,4 +22,14 @@ class SystemsControllerTest < ActionDispatch::IntegrationTest
     assert_equal BlackCandy::MinAppVersion::MINOR, response["minor"]
     assert_equal BlackCandy::MinAppVersion::PATCH, response["patch"]
   end
+
+  test "should get minimum cli version via api" do
+    get system_url, as: :json
+    response = @response.parsed_body["min_cli_version"]
+
+    assert_response :success
+    assert_equal BlackCandy::MinCliVersion::MAJOR, response["major"]
+    assert_equal BlackCandy::MinCliVersion::MINOR, response["minor"]
+    assert_equal BlackCandy::MinCliVersion::PATCH, response["patch"]
+  end
 end

--- a/test/controllers/transcoded_stream_controller_test.rb
+++ b/test/controllers/transcoded_stream_controller_test.rb
@@ -24,9 +24,7 @@ class TranscodedStreamControllerTest < ActionDispatch::IntegrationTest
     @stream_mock = StreamMock.new(songs(:flac_sample))
 
     cache_directory = "#{Stream::TRANSCODE_CACHE_DIRECTORY}/#{songs(:flac_sample).id}"
-    if Dir.exist?(cache_directory)
-      FileUtils.remove_dir(cache_directory)
-    end
+    FileUtils.rm_rf(cache_directory)
   end
 
   teardown do


### PR DESCRIPTION
## Summary

Expose `min_cli_version` from `GET /system` so CLI clients can check compatibility before logging in.

## Why

Servers can introduce API changes that older CLI releases do not support. Publishing a minimum compatible CLI version lets clients fail early with an upgrade message.

## Validation

- `mise exec ruby@3.3.7 -- bin/rails test test/controllers/systems_controller_test.rb`