### PR TITLE
fix: back off exponentially when retrying rate-limited Discogs cover fetch

### DIFF
--- a/app/jobs/attach_cover_image_from_discogs_job.rb
+++ b/app/jobs/attach_cover_image_from_discogs_job.rb
@@ -2,7 +2,7 @@
 
 require "open-uri"
 class AttachCoverImageFromDiscogsJob < ApplicationJob
-  retry_on Integrations::Service::TooManyRequests, wait: 1.minute, attempts: :unlimited
+  retry_on Integrations::Service::TooManyRequests, wait: :polynomially_longer, attempts: :unlimited
   queue_as :default
 
   def perform(imageable)


### PR DESCRIPTION
## What

Replaces the flat `wait: 1.minute` on `AttachCoverImageFromDiscogsJob`'s rate-limit retry with Rails' built-in `wait: :polynomially_longer` backoff.

## Why

As reported in #414: Discogs rate-limits to 60 authenticated requests/minute. With a large library, hundreds/thousands of jobs get queued after the first batch, and every one of them independently retries after exactly 60 seconds. That keeps the request rate pinned at the limit forever instead of letting it drain — `attempts: :unlimited` stays unlimited, but now the wait between retries grows with the number of attempts instead of staying flat.

## How this was tested

I don't have a Ruby/Rails environment in my sandbox, so I could not run `rails test:all` or `rails lint:all` locally. This is a one-line change to a `retry_on` keyword argument — no new logic. The existing test (`test/jobs/attach_cover_image_from_discogs_job_test.rb`, "should retry the job when api request has been rate limited") already exercises the retry-on-rate-limit path and doesn't assert on the wait duration, so it should be unaffected by this change, but I'd appreciate CI/a maintainer confirming.

Closes #414

---

**AI disclosure:** This PR (diff, commit message, and this description) was authored by an AI coding agent (Claude). I found no CONTRIBUTING.md or AI-usage policy in this repo to check against.
