### PR TITLE
fix: unload html5 audio nodes when switching songs

### DIFF
--- a/app/javascript/player.js
+++ b/app/javascript/player.js
@@ -13,6 +13,9 @@ class Player {
     dispatchEvent(document, 'player:beforePlaying')
 
     const song = this.playlist.songs[index]
+
+    if (this.currentSong !== song) { this.#unloadCurrentSong() }
+
     this.currentSong = song
     this.isPlaying = true
 
@@ -52,6 +55,7 @@ class Player {
     this.isPlaying = false
 
     Howler.stop()
+    this.#unloadCurrentSong()
 
     // reset current song
     this.currentSong = {}
@@ -94,6 +98,13 @@ class Player {
   get currentTime () {
     const currentTime = this.currentSong.howl ? this.currentSong.howl.seek() : 0
     return (typeof currentTime === 'number') ? currentTime : 0
+  }
+
+  #unloadCurrentSong () {
+    if (!this.currentSong.howl) { return }
+
+    this.currentSong.howl.unload()
+    delete this.currentSong.howl
   }
 }
 


### PR DESCRIPTION
In some cases, when user switch between songs, it will case whole page frozen. the root cause is 
Chrome and Firefox cap concurrent HTTP/1.1 connections at 6 per origin. Once six parked audio elements fill the pool, the browser cannot issue any request to that origin. then total page freeze.

it will fix a part of this issue https://github.com/blackcandy-org/blackcandy/issues/485